### PR TITLE
Java code starting point for the Coin Changer kata guided by properties

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>properties-kata</groupId>
+    <artifactId>java</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.5</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.9.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.quicktheories</groupId>
+            <artifactId>quicktheories</artifactId>
+            <version>0.25</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.pholser</groupId>
+            <artifactId>junit-quickcheck-core</artifactId>
+            <version>0.8</version>
+        </dependency>
+        <dependency>
+            <groupId>com.pholser</groupId>
+            <artifactId>junit-quickcheck-generators</artifactId>
+            <version>0.8</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>2.11.0</version>
+        </dependency>
+    </dependencies>
+
+    
+</project>

--- a/java/src/main/java/CoinChanger.java
+++ b/java/src/main/java/CoinChanger.java
@@ -1,0 +1,3 @@
+public class CoinChanger {
+
+}

--- a/java/src/test/java/CoinChangerProperties.java
+++ b/java/src/test/java/CoinChangerProperties.java
@@ -1,0 +1,15 @@
+import com.pholser.junit.quickcheck.Property;
+import com.pholser.junit.quickcheck.generator.InRange;
+import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
+import org.junit.runner.RunWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(JUnitQuickcheck.class)
+public class CoinChangerProperties {
+
+    @Property
+    public void should_do_some_magic(@InRange(minInt = 11, maxInt = 20) int value) {
+        assertThat(value).isLessThan(10);
+    }
+}


### PR DESCRIPTION
Java code for the Coin Changer kata to start playing around with property based testing, with the Junit-QuickCheck library.